### PR TITLE
remove duplicated date settings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -580,17 +580,6 @@ class RichFootSettingTab extends PluginSettingTab {
                     this.plugin.updateRichFoot();
                 }));
 
-        new Setting(containerEl)
-            .setName('Show Dates')
-            .setDesc('Show creation and modification dates in the footer')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.showDates)
-                .onChange(async (value) => {
-                    this.plugin.settings.showDates = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.updateRichFoot();
-                }));
-
         // Add Date Settings
         containerEl.createEl('h3', { text: 'Date Settings' });
         


### PR DESCRIPTION
Just found out that the "Show Dates" settings are duplicated, fix it:
![image](https://github.com/user-attachments/assets/ece17024-9351-45a7-9e06-12adadd3bf2c)
