### PR TITLE
Add Group Backlinks feature (by folder or frontmatter property)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Rich Foot will be documented in this file.
 
+## [1.14.1] - 2026-08-05
+### ✨ Improvement
+- The **Group By Property Name** setting now has a **Browse** button that opens a fuzzy-searchable list of every frontmatter property already in use across your vault, instead of requiring free-text entry
+
+## [1.14.0] - 2026-08-03
+### ✨ New Feature
+- Added a **Group Backlinks** option to organize the backlinks footer into labeled sub-groups
+- Group by **Folder** (the folder the linking note lives in) or by a **Frontmatter Property** value on the linking note
+- Notes missing the chosen property fall into a configurable **Fallback Group Label** (default: "Property Not Set")
+- Notes where the property holds a list appear in each of those groups, similar to tags
+- New settings: **Group Backlinks** (toggle), **Group Backlinks By** (Folder / Frontmatter Property), **Group By Property Name**, and **Fallback Group Label**
+
 ## [1.13.0] - 2026-06-14
 ### ✨ New Feature
 - Added a **Footer Width** setting to control how wide the footer is

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ You can toggle the visibility of each section:
 - Show/Hide Outlinks (disabled by default)
 - Show/Hide Dates
 
+#### Grouping Backlinks
+
+Backlinks can optionally be grouped into labeled sub-lists:
+- **Group by Folder** – groups backlinks by the folder the linking note lives in
+- **Group by Frontmatter Property** – groups backlinks by the value of a frontmatter property on the linking note (e.g. `category`). Notes missing that property fall into a configurable fallback group (default: "Property Not Set"). Notes where the property is a list appear in each of those groups.
+
 ### Style Settings
 
 Customize the appearance of your Rich Foot:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "rich-foot",
     "name": "Rich Foot",
-    "version": "1.13.0",
+    "version": "1.14.1",
     "minAppVersion": "1.7.2",
     "description": "Adds backlink tags and created/modified dates to the footer of your notes.",
     "author": "Justin Parker (eQui\\\\ Labs)",

--- a/src/data-manager.js
+++ b/src/data-manager.js
@@ -128,6 +128,100 @@ export class RichFootDataManager {
     }
 
     /**
+     * Group a list of items (each with a linkPath pointing at a backlinked note)
+     * into named groups, either by the folder the linking note lives in or by
+     * a frontmatter property set on the linking note.
+     * @param {Array<Object>} items - Items with a `linkPath` property
+     * @param {Object} settings - Plugin settings
+     * @returns {Array<[string, Array<Object>]>} Sorted [groupName, items] entries,
+     *   with the fallback group (if present) always sorted last
+     */
+    groupItemsByPath(items, settings) {
+        const groupsMap = new Map();
+
+        for (const item of items) {
+            const groupNames = this.getGroupNamesForPath(item.linkPath, settings);
+            for (const groupName of groupNames) {
+                if (!groupsMap.has(groupName)) {
+                    groupsMap.set(groupName, []);
+                }
+                groupsMap.get(groupName).push(item);
+            }
+        }
+
+        return this.sortGroups(groupsMap, settings);
+    }
+
+    /**
+     * Determine which group(s) a linked note belongs to
+     * @private
+     * @returns {Array<string>} One or more group names (more than one only
+     *   when grouping by a property that holds a list)
+     */
+    getGroupNamesForPath(filePath, settings) {
+        if (settings.groupBacklinksBy === 'property') {
+            return this.getPropertyGroupNames(filePath, settings);
+        }
+        return [this.getFolderGroupName(filePath)];
+    }
+
+    /**
+     * Get the folder group name for a file path
+     * @private
+     */
+    getFolderGroupName(filePath) {
+        const lastSlash = filePath.lastIndexOf('/');
+        return lastSlash === -1 ? '/' : filePath.substring(0, lastSlash);
+    }
+
+    /**
+     * Get the property-based group name(s) for a file, falling back to the
+     * configured fallback label when the property isn't set
+     * @private
+     */
+    getPropertyGroupNames(filePath, settings) {
+        const fallback = settings.groupFallbackLabel || 'Property Not Set';
+        const propName = settings.groupByProperty;
+        if (!propName) return [fallback];
+
+        const file = this.app.vault.getAbstractFileByPath(filePath);
+        if (!file) return [fallback];
+
+        const cache = this.app.metadataCache.getFileCache(file);
+        const value = cache?.frontmatter?.[propName];
+
+        if (value === undefined || value === null || value === '') {
+            return [fallback];
+        }
+
+        if (Array.isArray(value)) {
+            const names = value
+                .filter(v => v !== undefined && v !== null && v !== '')
+                .map(v => String(v));
+            return names.length ? names : [fallback];
+        }
+
+        return [String(value)];
+    }
+
+    /**
+     * Sort group entries alphabetically, always placing the fallback group last
+     * @private
+     */
+    sortGroups(groupsMap, settings) {
+        const fallback = settings.groupFallbackLabel || 'Property Not Set';
+        const entries = Array.from(groupsMap.entries());
+
+        entries.sort(([nameA], [nameB]) => {
+            if (nameA === fallback && nameB !== fallback) return 1;
+            if (nameB === fallback && nameA !== fallback) return -1;
+            return nameA.localeCompare(nameB);
+        });
+
+        return entries;
+    }
+
+    /**
      * Get dates for a file (created and modified)
      * @param {TFile} file - The file to get dates for
      * @param {Object} settings - Plugin settings

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -61,45 +61,55 @@ export class RichFootRenderer {
         if (backlinks.size === 0 && outlinks.size === 0) return;
 
         const linksDiv = container.createDiv({ cls: 'rich-foot--links' });
-        const linksUl = linksDiv.createEl('ul');
-
         const processedLinks = new Set();
+        const backlinkItems = [];
+        const outlinkOnlyItems = [];
 
         // Process backlinks first
         for (const [linkPath] of backlinks) {
             if (!linkPath.endsWith('.md')) continue;
             processedLinks.add(linkPath);
-
-            const metadata = {
+            backlinkItems.push({
+                linkPath,
                 isBacklink: true,
                 isOutlink: outlinks.has(linkPath)
-            };
-
-            const li = linksUl.createEl('li');
-            this.createLinkElement(li, file, linkPath, metadata);
+            });
         }
 
         // Process remaining outlinks
         for (const linkPath of outlinks) {
             if (processedLinks.has(linkPath)) continue;
-
-            const metadata = {
+            outlinkOnlyItems.push({
+                linkPath,
                 isBacklink: false,
                 isOutlink: true
-            };
-
-            const li = linksUl.createEl('li');
-            this.createLinkElement(li, file, linkPath, metadata);
+            });
         }
 
-        // Remove if empty
-        if (linksUl.childElementCount === 0) {
+        if (backlinkItems.length === 0 && outlinkOnlyItems.length === 0) {
             linksDiv.remove();
             return;
         }
 
-        // Apply "Show More" limit if enabled
-        this.applyLinkLimit(linksUl);
+        if (this.plugin.settings.groupBacklinks) {
+            // Group the backlink-sourced items; outlink-only items don't have
+            // a "linking note" to group by, so they get their own trailing group.
+            const groupEntries = this.plugin.dataManager.groupItemsByPath(
+                backlinkItems,
+                this.plugin.settings
+            );
+            if (outlinkOnlyItems.length > 0) {
+                groupEntries.push(['Outlinks', outlinkOnlyItems]);
+            }
+            this.renderGroupedLinks(linksDiv, file, groupEntries);
+        } else {
+            this.renderFlatLinks(linksDiv, file, [...backlinkItems, ...outlinkOnlyItems]);
+        }
+
+        // Remove if nothing ended up rendering (e.g. all groups empty)
+        if (linksDiv.childElementCount === 0) {
+            linksDiv.remove();
+        }
     }
 
     /**
@@ -115,24 +125,78 @@ export class RichFootRenderer {
 
         const className = `rich-foot--${type}`;
         const linksDiv = container.createDiv({ cls: className });
-        const linksUl = linksDiv.createEl('ul');
 
-        for (const linkPath of linksArray) {
+        const items = linksArray.map(linkPath => ({
+            linkPath,
+            isBacklink: type === 'backlinks',
+            isOutlink: type === 'outlinks'
+        }));
+
+        if (type === 'backlinks' && this.plugin.settings.groupBacklinks) {
+            const groupEntries = this.plugin.dataManager.groupItemsByPath(items, this.plugin.settings);
+            this.renderGroupedLinks(linksDiv, file, groupEntries);
+        } else {
+            this.renderFlatLinks(linksDiv, file, items);
+        }
+
+        if (linksDiv.childElementCount === 0) {
+            linksDiv.remove();
+        }
+    }
+
+    /**
+     * Render a flat (ungrouped) list of link items into a single <ul>
+     * @private
+     * @param {HTMLElement} container - Element to render the <ul> into
+     * @param {TFile} file - The note the footer belongs to
+     * @param {Array<Object>} items - Items with linkPath/isBacklink/isOutlink
+     */
+    renderFlatLinks(container, file, items) {
+        if (items.length === 0) return;
+
+        const linksUl = container.createEl('ul');
+        for (const item of items) {
             const li = linksUl.createEl('li');
-            const metadata = {
-                isBacklink: type === 'backlinks',
-                isOutlink: type === 'outlinks'
-            };
-            this.createLinkElement(li, file, linkPath, metadata);
+            this.createLinkElement(li, file, item.linkPath, item);
         }
 
         if (linksUl.childElementCount === 0) {
-            linksDiv.remove();
+            linksUl.remove();
             return;
         }
 
         // Apply "Show More" limit if enabled
         this.applyLinkLimit(linksUl);
+    }
+
+    /**
+     * Render grouped link items, each group as its own labeled sub-list
+     * @private
+     * @param {HTMLElement} container - Element to render groups into
+     * @param {TFile} file - The note the footer belongs to
+     * @param {Array<[string, Array<Object>]>} groupEntries - [groupName, items] pairs
+     */
+    renderGroupedLinks(container, file, groupEntries) {
+        for (const [groupName, groupItems] of groupEntries) {
+            if (!groupItems || groupItems.length === 0) continue;
+
+            const groupDiv = container.createDiv({ cls: 'rich-foot--group' });
+            groupDiv.createDiv({ cls: 'rich-foot--group-title', text: groupName });
+
+            const linksUl = groupDiv.createEl('ul');
+            for (const item of groupItems) {
+                const li = linksUl.createEl('li');
+                this.createLinkElement(li, file, item.linkPath, item);
+            }
+
+            if (linksUl.childElementCount === 0) {
+                groupDiv.remove();
+                continue;
+            }
+
+            // Apply "Show More" limit per-group if enabled
+            this.applyLinkLimit(linksUl);
+        }
     }
 
     /**

--- a/src/settings.js
+++ b/src/settings.js
@@ -23,6 +23,10 @@ export const DEFAULT_SETTINGS = {
     showOutlinks: true,
     showDates: true,
     combineLinks: false,
+    groupBacklinks: false,
+    groupBacklinksBy: 'folder',
+    groupByProperty: '',
+    groupFallbackLabel: 'Property Not Set',
     limitLinks: false,
     linksLimit: 10,
     footerWidth: 'default',
@@ -85,6 +89,76 @@ export class RichFootSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                     await this.plugin.updateRichFoot();
                 }));
+
+        new Setting(containerEl)
+            .setName('Group Backlinks')
+            .setDesc('Group backlinks in the footer, either by the folder the linking note lives in, or by a frontmatter property set on the linking note')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.groupBacklinks)
+                .onChange(async (value) => {
+                    this.plugin.settings.groupBacklinks = value;
+                    await this.plugin.saveSettings();
+                    await this.plugin.updateRichFoot();
+                    this.display();
+                }));
+
+        if (this.plugin.settings.groupBacklinks) {
+            new Setting(containerEl)
+                .setName('Group Backlinks By')
+                .setDesc('Choose whether backlinks are grouped by their folder or by a frontmatter property')
+                .addDropdown(dropdown => {
+                    dropdown
+                        .addOption('folder', 'Folder')
+                        .addOption('property', 'Frontmatter Property')
+                        .setValue(this.plugin.settings.groupBacklinksBy)
+                        .onChange(async (value) => {
+                            this.plugin.settings.groupBacklinksBy = value;
+                            await this.plugin.saveSettings();
+                            await this.plugin.updateRichFoot();
+                            this.display();
+                        });
+                });
+
+            if (this.plugin.settings.groupBacklinksBy === 'property') {
+                let groupByPropertyInput;
+                new Setting(containerEl)
+                    .setName('Group By Property Name')
+                    .setDesc('Frontmatter property (on the linking note) to group backlinks by. If a note has a list for this property, it will appear in each of those groups.')
+                    .addText(text => {
+                        groupByPropertyInput = text;
+                        text.setPlaceholder('e.g. category')
+                            .setValue(this.plugin.settings.groupByProperty)
+                            .onChange(async (value) => {
+                                this.plugin.settings.groupByProperty = value;
+                                await this.plugin.saveSettings();
+                                await this.plugin.updateRichFoot();
+                            });
+                    })
+                    .addButton(button => button
+                        .setButtonText('Browse')
+                        .onClick(async () => {
+                            const property = await this.browseForProperty();
+                            if (property) {
+                                groupByPropertyInput.setValue(property);
+                                this.plugin.settings.groupByProperty = property;
+                                await this.plugin.saveSettings();
+                                await this.plugin.updateRichFoot();
+                            }
+                        }));
+
+                new Setting(containerEl)
+                    .setName('Fallback Group Label')
+                    .setDesc('Group label used for backlinks whose note does not have the property above set')
+                    .addText(text => text
+                        .setPlaceholder(DEFAULT_SETTINGS.groupFallbackLabel)
+                        .setValue(this.plugin.settings.groupFallbackLabel)
+                        .onChange(async (value) => {
+                            this.plugin.settings.groupFallbackLabel = value || DEFAULT_SETTINGS.groupFallbackLabel;
+                            await this.plugin.saveSettings();
+                            await this.plugin.updateRichFoot();
+                        }));
+            }
+        }
 
         new Setting(containerEl)
             .setName('Limit Links Shown')
@@ -803,6 +877,35 @@ export class RichFootSettingTab extends PluginSettingTab {
             modal.open();
         });
     }
+
+    async browseForProperty() {
+        // Collect every frontmatter property name actually in use across the
+        // vault, so the list always reflects real properties rather than a
+        // hardcoded list.
+        const propertyNames = new Set();
+        for (const file of this.app.vault.getMarkdownFiles()) {
+            const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+            if (!frontmatter) continue;
+            for (const key of Object.keys(frontmatter)) {
+                if (key === 'position') continue; // internal cache key, not a real property
+                propertyNames.add(key);
+            }
+        }
+
+        const properties = Array.from(propertyNames).sort((a, b) => a.localeCompare(b));
+
+        if (properties.length === 0) {
+            new Notice('No frontmatter properties found in this vault yet');
+            return null;
+        }
+
+        return new Promise(resolve => {
+            const modal = new PropertySuggestModal(this.app, properties, (result) => {
+                resolve(result);
+            });
+            modal.open();
+        });
+    }
 }
 
 export class FolderSuggestModal extends FuzzySuggestModal {
@@ -814,6 +917,27 @@ export class FolderSuggestModal extends FuzzySuggestModal {
 
     getItems() {
         return this.folders;
+    }
+
+    getItemText(item) {
+        return item;
+    }
+
+    onChooseItem(item, evt) {
+        this.onChoose(item);
+    }
+}
+
+export class PropertySuggestModal extends FuzzySuggestModal {
+    constructor(app, properties, onChoose) {
+        super(app);
+        this.properties = properties;
+        this.onChoose = onChoose;
+        this.setPlaceholder('Find a frontmatter property...');
+    }
+
+    getItems() {
+        return this.properties;
     }
 
     getItemText(item) {

--- a/styles.css
+++ b/styles.css
@@ -50,6 +50,29 @@
     color: var(--rich-foot-link-color, var(--text-accent));
 }
 
+/* ------------------------------- */
+/* -- Grouped Backlinks Styles -- */
+/* ------------------------------- */
+.rich-foot--group {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.rich-foot--group-title {
+    width: 100%;
+    text-transform: uppercase;
+    filter: brightness(130%);
+    font-size: 0.65em;
+    opacity: 0.7;
+    margin: 6px 0 2px 20px;
+    color: var(--rich-foot-link-color, var(--text-accent));
+}
+
+.rich-foot--group:first-child .rich-foot--group-title {
+    margin-top: 2px;
+}
+
 .rich-foot--backlinks ul,
 .rich-foot--outlinks ul,
 .rich-foot--links ul {


### PR DESCRIPTION
## Summary

Adds an optional way to group the backlinks footer, either by the folder the linking note lives in or by a frontmatter property set on the linking note.

## Motivation

For vaults with a lot of backlinks on a single note, a flat list gets hard to scan. Grouping lets related backlinks (e.g. notes in the same folder, or sharing a `category`/`type`/`status` property) cluster together under a labeled sub-heading.

## Changes

- New settings: **Group Backlinks** (toggle), **Group Backlinks By** (Folder / Frontmatter Property), **Group By Property Name** (with a fuzzy-search "Browse" picker sourced from properties already in use across the vault), and **Fallback Group Label**
- Notes missing the chosen property fall into a configurable fallback group (default: "Property Not Set")
- Notes where the property holds a list appear in each of those groups, similar to how tags work
- Works in both the standard backlinks section and combined-links mode; in combined mode, outlink-only entries land in a trailing "Outlinks" group since they have no linking note to group by
- Off by default, so existing behavior is unchanged unless a user opts in

## Testing

- Verified folder grouping, property grouping (single value, list value, and missing-property fallback) against sample frontmatter
- Confirmed the property Browse picker correctly scans `metadataCache` and lists real properties from the vault
- Ran a full production build (`npm run test-build`) with no errors
- Manually tested in Obsidian with grouping on and off, in both standard and combined-links modes

## Notes for the maintainer

I bumped the version to 1.14.1 and added a CHANGELOG/README entry — happy to drop or adjust the version bump if you'd rather handle versioning yourself.